### PR TITLE
Fix redirecting get request with query string

### DIFF
--- a/sesame/compatibility.py
+++ b/sesame/compatibility.py
@@ -1,4 +1,8 @@
+import sys
 try:
-    from urllib.parse import urlencode                      # noqa: F401
+    if sys.version_info >= (3, 0):
+        from urllib.parse import urlencode                      # noqa: F401
+    else:
+        from urllib import urlencode                            # noqa: F401
 except ImportError:                                         # pragma: no cover
     from urllib import urlencode                            # noqa: F401


### PR DESCRIPTION
Hi @aaugustin 
I'm not sure why but redirecting with query string adds a weird `'` at the end of the param. 
Following this [https://stackoverflow.com/a/3766503/2302131](url) SO answer I created this PR