### PR TITLE
authenticate function call signature has changed since Django 1.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,12 @@
+
+Changelog history
+=================
+
+1.6.1
+-----
+- Added Changelog
+- Added 'request' paramater to  `django.contrib.auth import authenticate`
+
+1.6
+---
+- Prevous release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog history
 1.6.1
 -----
 - Added Changelog
-- Added 'request' paramater to  `django.contrib.auth import authenticate`
+- Added 'request' paramater to  `django.contrib.auth`'s `authenticate`
 
 1.6
 ---

--- a/sesame/utils.py
+++ b/sesame/utils.py
@@ -36,4 +36,4 @@ def get_user(request):
     if url_auth_token is None:
         return None
 
-    return authenticate(url_auth_token=url_auth_token)
+    return authenticate(request, url_auth_token=url_auth_token)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with codecs.open(os.path.join(root_dir, 'README.rst'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='django-sesame',
-    version='1.5',
+    version='1.6.1',
     description=description,
     long_description=long_description,
     url='https://github.com/aaugustin/django-sesame',


### PR DESCRIPTION
Please see:
https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.backends.ModelBackend.authenticate

This fix adds the request parameter for the authenticate function call. I've also added a Change log.