### PR TITLE
Add support for Django 3.1 and Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Requirements
 
 django-sesame is tested with:
 
-- Django 2.2 (LTS) and 3.0;
+- Django 2.2 (LTS), 3.0, and 3.1;
 - Python ≥ 3.6
 
 It builds upon ``django.contrib.auth``. It supports custom user models,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
+    "Framework :: Django :: 3.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
 ]

--- a/src/sesame/tokens_v1.py
+++ b/src/sesame/tokens_v1.py
@@ -33,7 +33,7 @@ def get_revocation_key(user):
     # the token. (Remember, if an attacker obtains the URL, he can already
     # log in. This isn't high security.)
     return crypto.pbkdf2(
-        data, settings.SALT, settings.ITERATIONS, digest=settings.DIGEST,
+        data, settings.SALT, settings.ITERATIONS, digest=settings.DIGEST
     )
 
 

--- a/tests/test_packers.py
+++ b/tests/test_packers.py
@@ -128,11 +128,11 @@ class TestPackers(TestCase):
             with override_settings(AUTH_USER_MODEL="tests.BooleanUser"):
                 pass  # pragma: no cover
         self.assertEqual(
-            str(exc.exception), "BooleanField primary keys aren't supported",
+            str(exc.exception), "BooleanField primary keys aren't supported"
         )
 
     @override_settings(
-        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer",
+        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer"
     )
     def test_get_packer_with_custom_packer(self):
         self.assertEqual(type(packers.packer), Packer)

--- a/tests/test_tokens_v1.py
+++ b/tests/test_tokens_v1.py
@@ -143,7 +143,7 @@ class TestTokensV1(CaptureLogMixin, CreateUserMixin, TestCase):
     # Test custom primary key packer
 
     @override_settings(
-        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer",
+        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer"
     )
     def test_custom_packer_is_used(self):
         user = self.create_user(username="abcdef012345abcdef567890")

--- a/tests/test_tokens_v2.py
+++ b/tests/test_tokens_v2.py
@@ -181,7 +181,7 @@ class TestTokensV2(CaptureLogMixin, CreateUserMixin, TestCase):
     # Test custom primary key packer
 
     @override_settings(
-        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer",
+        AUTH_USER_MODEL="tests.StrUser", SESAME_PACKER="tests.test_packers.Packer"
     )
     def test_custom_packer_is_used(self):
         # CreateUserMixin.setUp() ran before @override_settings changed the

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = true
 envlist =
     py{36,37}-django22
     py{36,37,38}-django30
-    py{36,37,38}-django31
+    py{36,37,38,39}-django31
     style
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,10 @@ commands =
 
 [testenv:style]
 deps =
-    black
+    black>=20.8b1
     flake8
-    isort
+    isort>=5.5
 commands =
-    isort --check-only --project sesame --recursive src tests
+    isort --check-only --project sesame src tests
     black --check src tests
     flake8 src tests
-

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,14 @@ isolated_build = true
 envlist =
     py{36,37}-django22
     py{36,37,38}-django30
+    py{36,37,38}-django31
     style
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 extras =
     ua
 commands =


### PR DESCRIPTION
- Django 3.1 is available since 2020-08-04, see https://www.djangoproject.com/weblog/2020/aug/04/django-31-released/
- Python 3.9.0 final is expected on Monday, 2020-10-05, see https://www.python.org/dev/peps/pep-0596/#schedule