### PR TITLE
Fix docs spellcheck

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,6 +1,7 @@
 backend
 Changelog
 django
+durations
 frictionless
 hasher
 hashers


### PR DESCRIPTION
For some reason the dictionary includes “duration” but not “durations”.