### PR TITLE
Test on Django 4.0 and Python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Requirements
 
 django-sesame is tested with:
 
-- Django 2.2 (LTS), 3.0, 3.1, and 3.2 (LTS);
+- Django 2.2 (LTS), 3.0, 3.1, 3.2 (LTS), and 4.0
 - Python ≥ 3.6
 
 It builds upon ``django.contrib.auth``. It supports custom user models,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
 ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,3 +32,5 @@ SECRET_KEY = "Anyone who finds a URL will be able to log in. Seriously."
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 TEMPLATES = [{"BACKEND": "django.template.backends.django.DjangoTemplates"}]
+
+USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py37-django30
     py38-django31
     py39-django32
+    py310-django40
     style
 
 [testenv]
@@ -13,10 +14,11 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
 extras =
     ua
 commands =
-    python -m django test --settings=tests.settings
+    python -W error::ResourceWarning -W error::DeprecationWarning -W error::PendingDeprecationWarning -m django test --settings=tests.settings
 
 [testenv:style]
 deps =


### PR DESCRIPTION
Add Django 4.0 on Python 3.10 to the test matrix.

Set `USE_TZ = True` in test settings since without it Django 4.0 raises a deprecation warning.

Add Python flags to fail for resource and deprecation warnings - this is something I like to do for libraries to check that warnings aren't passed on to users.