### PR TITLE
Add support for custom user keys in tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -481,7 +481,7 @@ Alternate user keys
 If your user model has multiple unique keys, it may be desireable to use one 
 other than actual primary key in the token.
 
-Use the optional parameter `user_pk` when creating a token, token parameters,
+Use the optional parameter `user_key` when creating a token, token parameters,
 or query string. Then in your middleware backend, make sure your `get_user`
 method can return a user record when given this key.
 
@@ -489,7 +489,7 @@ method can return a user record when given this key.
 
     from sesame.backends import ModelBackend
 
-    class ExamplBackend(ModelBackend):
+    class ExampleBackend(ModelBackend):
         def get_user(self, user_key):
             try:
                 return User.objects.get(key=user_key)

--- a/README.rst
+++ b/README.rst
@@ -475,6 +475,31 @@ custom packer class.
 For details, read ``help(BasePacker)`` and look at built-in packers defined in
 the ``sesame.packers`` module.
 
+Alternate user keys
+-------------------
+
+If your user model has multiple unique keys, it may be desireable to use one 
+other than actual primary key in the token.
+
+Use the optional parameter `user_pk` when creating a token, token parameters,
+or query string. Then in your middleware backend, make sure your `get_user`
+method can return a user record when given this key.
+
+.. code:: python
+
+    from sesame.backends import ModelBackend
+
+    class ExamplBackend(ModelBackend):
+        def get_user(self, user_key):
+            try:
+                return User.objects.get(key=user_key)
+            except User.DoesNotExist:
+                return None
+
+Beware, if the key you provide for a user's token is not actually unique,
+then your backend may return a user different from the owner of the token
+granting access to the wrong account.
+
 Stateless authentication
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -500,6 +500,11 @@ Beware, if the key you provide for a user's token is not actually unique,
 then your backend may return a user different from the owner of the token
 granting access to the wrong account.
 
+Lastly, make sure you set Sesame's packer setting `SESAME_PACKER` to match the
+new type, as it will choose the user model's primary key type by default. For
+example, you can use the native packers already in Sesame if needed, or supply
+your own custom packer.
+
 Stateless authentication
 ------------------------
 

--- a/src/sesame/tokens.py
+++ b/src/sesame/tokens.py
@@ -7,13 +7,13 @@ logger = logging.getLogger("sesame")
 __all__ = ["create_token", "parse_token"]
 
 
-def create_token(user, scope=""):
+def create_token(user, scope="", user_pk=None):
     """
     Create a signed token for a user and an optional scope.
 
     """
     tokens = settings.TOKENS[0]
-    return tokens.create_token(user, scope)
+    return tokens.create_token(user, scope, user_pk)
 
 
 def parse_token(token, get_user, scope="", max_age=None):

--- a/src/sesame/tokens.py
+++ b/src/sesame/tokens.py
@@ -7,13 +7,13 @@ logger = logging.getLogger("sesame")
 __all__ = ["create_token", "parse_token"]
 
 
-def create_token(user, scope="", user_pk=None):
+def create_token(user, scope="", user_key=None):
     """
     Create a signed token for a user and an optional scope.
 
     """
     tokens = settings.TOKENS[0]
-    return tokens.create_token(user, scope, user_pk)
+    return tokens.create_token(user, scope, user_key)
 
 
 def parse_token(token, get_user, scope="", max_age=None):

--- a/src/sesame/tokens_v1.py
+++ b/src/sesame/tokens_v1.py
@@ -74,14 +74,17 @@ def unsign(token):
     return signing.b64_decode(data.encode())
 
 
-def create_token(user, scope=""):
+def create_token(user, scope="", user_pk=None):
     """
     Create a v1 signed token for a user.
 
     """
     if scope != "":
         raise NotImplementedError("v1 tokens don't support scope")
-    primary_key = packers.packer.pack_pk(user.pk)
+    if not user_pk:
+        user_pk = user.pk
+
+    primary_key = packers.packer.pack_pk(user_pk)
     key = get_revocation_key(user)
     return sign(primary_key + key)
 

--- a/src/sesame/tokens_v1.py
+++ b/src/sesame/tokens_v1.py
@@ -74,17 +74,17 @@ def unsign(token):
     return signing.b64_decode(data.encode())
 
 
-def create_token(user, scope="", user_pk=None):
+def create_token(user, scope="", user_key=None):
     """
     Create a v1 signed token for a user.
 
     """
     if scope != "":
         raise NotImplementedError("v1 tokens don't support scope")
-    if not user_pk:
-        user_pk = user.pk
+    if not user_key:
+        user_key = user.pk
 
-    primary_key = packers.packer.pack_pk(user_pk)
+    primary_key = packers.packer.pack_pk(user_key)
     key = get_revocation_key(user)
     return sign(primary_key + key)
 

--- a/src/sesame/tokens_v2.py
+++ b/src/sesame/tokens_v2.py
@@ -121,12 +121,15 @@ def sign(data):
     ).digest()
 
 
-def create_token(user, scope=""):
+def create_token(user, scope="", user_pk=None):
     """
     Create a v2 signed token for a user.
 
     """
-    primary_key = packers.packer.pack_pk(user.pk)
+    if not user_pk:
+        user_pk = user.pk
+
+    primary_key = packers.packer.pack_pk(user_pk)
     timestamp = pack_timestamp()
     revocation_key = get_revocation_key(user)
 

--- a/src/sesame/tokens_v2.py
+++ b/src/sesame/tokens_v2.py
@@ -121,15 +121,15 @@ def sign(data):
     ).digest()
 
 
-def create_token(user, scope="", user_pk=None):
+def create_token(user, scope="", user_key=None):
     """
     Create a v2 signed token for a user.
 
     """
-    if not user_pk:
-        user_pk = user.pk
+    if not user_key:
+        user_key = user.pk
 
-    primary_key = packers.packer.pack_pk(user_pk)
+    primary_key = packers.packer.pack_pk(user_key)
     timestamp = pack_timestamp()
     revocation_key = get_revocation_key(user)
 

--- a/src/sesame/utils.py
+++ b/src/sesame/utils.py
@@ -9,20 +9,20 @@ from .tokens import create_token as get_token
 __all__ = ["get_token", "get_parameters", "get_query_string", "get_user"]
 
 
-def get_parameters(user, scope=""):
+def get_parameters(user, scope="", user_pk=None):
     """
     Return GET parameters to authenticate a user.
 
     """
-    return {settings.TOKEN_NAME: get_token(user, scope)}
+    return {settings.TOKEN_NAME: get_token(user, scope, user_pk)}
 
 
-def get_query_string(user, scope=""):
+def get_query_string(user, scope="", user_pk=None):
     """
     Return a complete query string to authenticate a user.
 
     """
-    return "?" + urlencode(get_parameters(user, scope))
+    return "?" + urlencode(get_parameters(user, scope, user_pk))
 
 
 def get_user(request_or_sesame, update_last_login=None, scope="", max_age=None):

--- a/src/sesame/utils.py
+++ b/src/sesame/utils.py
@@ -9,20 +9,20 @@ from .tokens import create_token as get_token
 __all__ = ["get_token", "get_parameters", "get_query_string", "get_user"]
 
 
-def get_parameters(user, scope="", user_pk=None):
+def get_parameters(user, scope="", user_key=None):
     """
     Return GET parameters to authenticate a user.
 
     """
-    return {settings.TOKEN_NAME: get_token(user, scope, user_pk)}
+    return {settings.TOKEN_NAME: get_token(user, scope, user_key)}
 
 
-def get_query_string(user, scope="", user_pk=None):
+def get_query_string(user, scope="", user_key=None):
     """
     Return a complete query string to authenticate a user.
 
     """
-    return "?" + urlencode(get_parameters(user, scope, user_pk))
+    return "?" + urlencode(get_parameters(user, scope, user_key))
 
 
 def get_user(request_or_sesame, update_last_login=None, scope="", max_age=None):

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -28,6 +28,10 @@ class CreateUserMixin(TestCase):
     def get_user(user_id):
         return get_user_model().objects.filter(pk=user_id).first()
 
+    @staticmethod
+    def get_custom_user(user_key):
+        return get_user_model().objects.filter(id=user_key).first()
+
 
 class CaptureLogMixin(unittest.TestCase):
 

--- a/tests/test_tokens_v1.py
+++ b/tests/test_tokens_v1.py
@@ -19,6 +19,13 @@ class TestTokensV1(CaptureLogMixin, CreateUserMixin, TestCase):
         self.assertEqual(user, self.user)
         self.assertLogsContain("Valid token for user john")
 
+    def test_valid_token_custom_user_key(self):
+        token = create_token(self.user, user_pk=1)
+        self.assertTrue(detect_token(token))
+        user = parse_token(token, self.get_custom_user)
+        self.assertEqual(user, self.user)
+        self.assertLogsContain("Valid token for user john")
+
     # Test invalid tokens
 
     def test_invalid_signature(self):

--- a/tests/test_tokens_v1.py
+++ b/tests/test_tokens_v1.py
@@ -20,7 +20,7 @@ class TestTokensV1(CaptureLogMixin, CreateUserMixin, TestCase):
         self.assertLogsContain("Valid token for user john")
 
     def test_valid_token_custom_user_key(self):
-        token = create_token(self.user, user_pk=1)
+        token = create_token(self.user, user_key=1)
         self.assertTrue(detect_token(token))
         user = parse_token(token, self.get_custom_user)
         self.assertEqual(user, self.user)

--- a/tests/test_tokens_v2.py
+++ b/tests/test_tokens_v2.py
@@ -27,7 +27,7 @@ class TestTokensV2(CaptureLogMixin, CreateUserMixin, TestCase):
         self.assertLogsContain("Valid token for user john in default scope")
 
     def test_valid_token_custom_user_key(self):
-        token = create_token(self.user, user_pk=1)
+        token = create_token(self.user, user_key=1)
         self.assertTrue(detect_token(token))
         user = parse_token(token, self.get_custom_user)
         self.assertEqual(user, self.user)

--- a/tests/test_tokens_v2.py
+++ b/tests/test_tokens_v2.py
@@ -26,6 +26,13 @@ class TestTokensV2(CaptureLogMixin, CreateUserMixin, TestCase):
         self.assertEqual(user, self.user)
         self.assertLogsContain("Valid token for user john in default scope")
 
+    def test_valid_token_custom_user_key(self):
+        token = create_token(self.user, user_pk=1)
+        self.assertTrue(detect_token(token))
+        user = parse_token(token, self.get_custom_user)
+        self.assertEqual(user, self.user)
+        self.assertLogsContain("Valid token for user john in default scope")
+
     # Test invalid tokens
 
     @override_settings(SESAME_MAX_AGE=300)


### PR DESCRIPTION
Adds an optional feature when creating tokens to use a custom key for the user. Useful when for example the existing user model has an int primary key as well as a unique UUID. Normally the token would use the `user.pk` which leaves your user ID in the clear in the resulting token, but now you can specify using the UUID instead without altering your model at all.