### PR TITLE
Interpolate view arguments in decorator scope.

### DIFF
--- a/src/sesame/decorators.py
+++ b/src/sesame/decorators.py
@@ -44,7 +44,7 @@ def authenticate(
         user = get_user(
             request,
             update_last_login=False if permanent else None,
-            scope=scope,
+            scope=scope.format(*args, **kwargs),
             max_age=max_age,
         )
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -63,6 +63,24 @@ class TestAuthenticate(CreateUserMixin, TestCase):
         self.assertEqual(response.wsgi_request.user, user1)
         self.assertContains(response, user1.username)
 
+    def test_scope(self):
+        params = get_parameters(self.user, scope="scope")
+        response = self.client.get("/authenticate/scope/", params)
+        self.assertEqual(response.wsgi_request.user, self.user)
+        self.assertContains(response, self.user.username)
+
+    def test_scope_interpolate_positional_argument(self):
+        params = get_parameters(self.user, scope="arg:spam")
+        response = self.client.get("/authenticate/scope/arg/spam/", params)
+        self.assertEqual(response.wsgi_request.user, self.user)
+        self.assertContains(response, self.user.username)
+
+    def test_scope_interpolate_keyword_argument(self):
+        params = get_parameters(self.user, scope="kwarg:eggs")
+        response = self.client.get("/authenticate/scope/kwarg/eggs/", params)
+        self.assertEqual(response.wsgi_request.user, self.user)
+        self.assertContains(response, self.user.username)
+
     @override_settings(MIDDLEWARE=[])
     def test_without_session_middleware(self):
         params = get_parameters(self.user)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -6,11 +6,23 @@ from sesame.views import LoginView
 from .views import show_user
 
 urlpatterns = [
+    # For test_decorators.TestAuthenticate
     path("authenticate/", authenticate(show_user)),
     path("authenticate/not_required/", authenticate(required=False)(show_user)),
     path("authenticate/permanent/", authenticate(permanent=True)(show_user)),
     path("authenticate/no_override/", authenticate(override=False)(show_user)),
+    path("authenticate/scope/", authenticate(scope="scope")(show_user)),
+    re_path(
+        r"authenticate/scope/arg/([a-z])/",
+        authenticate(scope="arg:{}")(show_user),
+    ),
+    re_path(
+        r"authenticate/scope/kwarg/(?P<kwarg>[a-z]+)/",
+        authenticate(scope="kwarg:{kwarg}")(show_user),
+    ),
+    # For test_views.TestLoginView
     path("login/", LoginView.as_view()),
     path("login/no_redirect/", LoginView.as_view(next_page=None)),
+    # For test_middleware.TestMiddleware
     re_path("", show_user),  # catchall pattern
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,7 +2,7 @@ from django.http import HttpResponse
 from django.template import engines
 
 
-def show_user(request):
+def show_user(request, *args, **kwargs):
     content = (
         engines["django"]
         .from_string(


### PR DESCRIPTION
Typical use of scope is: scope=f"object_type:{object_id}". This change
makes it possible to use the decorator with such scopes, as follows:

    @authenticate(scope="object_type:{object_id}")
    def view(request, object_id):
        ...