### PR TITLE
Skip User.EMAIL_FIELD check if not invalidating on email change

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -63,7 +63,7 @@ Settings
 .. data:: SESAME_INVALIDATE_ON_EMAIL_CHANGE
     :value: False
 
-    Set :data:`SESAME_INVALIDATE_ON_PASSWORD_CHANGE` to :obj:`True` to
+    Set :data:`SESAME_INVALIDATE_ON_EMAIL_CHANGE` to :obj:`True` to
     invalidate tokens when a user changes their email.
 
 .. data:: SESAME_PRIMARY_KEY_FIELD

--- a/src/sesame/settings.py
+++ b/src/sesame/settings.py
@@ -110,14 +110,15 @@ def check():
         )
 
     global INVALIDATE_ON_EMAIL_CHANGE
-    User = get_user_model()
-    try:
-        User._meta.get_field(User.get_email_field_name())
-    except FieldDoesNotExist:
-        raise ImproperlyConfigured(
-            "invalid configuration: set User.EMAIL_FIELD correctly "
-            "or set SESAME_INVALIDATE_ON_EMAIL_CHANGE to False"
-        )
+    if INVALIDATE_ON_EMAIL_CHANGE:
+        User = get_user_model()
+        try:
+            User._meta.get_field(User.get_email_field_name())
+        except FieldDoesNotExist:
+            raise ImproperlyConfigured(
+                "invalid configuration: set User.EMAIL_FIELD correctly "
+                "or set SESAME_INVALIDATE_ON_EMAIL_CHANGE to False"
+            )
 
 
 check()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ class TestSettings(TestCase):
         )
 
     @override_settings(
-        SESAME_INVALIDATE_ON_EMAIL_CHANGE=False,
+        SESAME_INVALIDATE_ON_EMAIL_CHANGE=True,
         AUTH_USER_MODEL="tests.StrUser",
     )
     def test_invalid_configuration(self):


### PR DESCRIPTION
Fixes a breaking change in 3.2 for us where in our use case the User is allowed multiple email addresses so one field on the User model is not sufficient. We do provide various computed properties to access a User's various email addresses, but supporting this use case feels out of scope here. I think it makes sense to avoid inspecting the User model if no email invalidation is happening?

Also fixes a copy-paste typo for the `SESAME_INVALIDATE_ON_EMAIL_CHANGE` reference in the docs.